### PR TITLE
fix on_disconnect callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed:
+
+- Fix crushing when the client lost connection, [PR-6](https://github.com/panda-official/DriftMqtt/pull/6)
+
 ## 0.2.1 - 2023-05--10
 
 ### Fixed:

--- a/pkg/drift_mqtt/client.py
+++ b/pkg/drift_mqtt/client.py
@@ -88,7 +88,7 @@ class Client:
             )
 
     @staticmethod
-    def on_disconnect(_client, _userdata, return_code):
+    def on_disconnect(_client, _userdata, return_code, _properties=None):
         """Callback on mqtt disconnected"""
         # this is a bug in paho, return_code 1 is a general error
         # (connection lost in this case)


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The library crashed when the client loses its MQTT connection.

### What is the new behavior?

`on_disconnect` callback was for MQTT3.1 but we didn't changed when we moved om MQTT5

### Does this PR introduce a breaking change?

No

### Other information:
